### PR TITLE
Pins API using keyring

### DIFF
--- a/R/uth_set_pins_api_key.R
+++ b/R/uth_set_pins_api_key.R
@@ -1,0 +1,34 @@
+#' This function sets the API key for the pins package using the `keyring` package. It allows users to choose between a production or test environment and provides an option to overwrite an existing key. see the UT Connect Posit Servers for your api keys `https://connect.ie.utahtech.edu/ `for Prod or `https://connect.test.ie.utahtech.edu/` for Test.
+#'
+#' @param prod Logical, if TRUE sets the key for the Posit Connect production environment, if FALSE sets it for the test environment.
+#' @param overwrite Logical, if TRUE allows overwriting an existing key.
+#'
+#' @returns NULL, but sets the API key in the keyring.
+#' @export
+#' @importFrom keyring key_set key_get
+
+uth_set_pins_api_key <- function(prod = TRUE, overwrite = FALSE) {
+
+  service_choice <- if (prod) "pins" else "pins_test"
+  message("Using service: ", service_choice)
+
+  # Check if key already exists
+  key_exists <- tryCatch({
+    keyring::key_get(service = service_choice, username = "api_key")
+    TRUE
+  }, error = function(e) {
+    FALSE
+  })
+
+  if (key_exists && !overwrite) {
+    message("API key already exists for '", service_choice, "'. Use `overwrite = TRUE` to reset it.")
+  } else {
+    tryCatch({
+      keyring::key_set(service = service_choice, username = "api_key",
+                       prompt = "Please enter your API key:")
+      message("API key successfully set.")
+    }, error = function(e) {
+      message("Failed to set API key: ", e$message)
+    })
+  }
+}


### PR DESCRIPTION
## What This Update Does

This update adds a new function to the R package called `uth_set_pins_api_key()`. This function helps users securely store their API keys, which are needed to connect to Posit Connect servers using the `pins` package. It uses the `keyring` package to store the key safely on the user's system.

## Why This Is Useful

When working with shared data in R, the `pins` package is often used to connect to a server. To do this securely, users need to provide an API key. Instead of typing the key directly into the code (which can be insecure), this function allows users to store it securely in their system's keyring.

## Choosing the Right Server

The function allows users to choose between two environments:
- **Production**: The live server with official data (`https://connect.ie.utahtech.edu/`)
- **Test**: A sandbox server for testing purposes (`https://connect.test.ie.utahtech.edu/`)

Users can select the environment by setting the `prod` argument to `TRUE` (for production) or `FALSE` (for test).

## Overwriting Keys
If a key has already been saved, the function checks for it. By default, it will not overwrite an existing key unless the user explicitly sets `overwrite = TRUE`.

## How It Works
1. The user specifies whether they want to use the production or test server.
2. The function checks if a key already exists for that environment.
3. If no key exists, or if `overwrite = TRUE`, the function prompts the user to enter their API key.
4. The key is then saved securely using the `keyring` package.

## Where to Get Your API Key

Users can retrieve their API keys from the appropriate Posit Connect server:
- Production: [https://connect.ie.utahtech.edu/](https://connect.ie.utahtech.ie.utahtech.edu/](https://connect